### PR TITLE
add --help and -h options to pyfinalo_py

### DIFF
--- a/src/bin_pyfinalo_py/bin_pyfinalo_py.ml
+++ b/src/bin_pyfinalo_py/bin_pyfinalo_py.ml
@@ -73,6 +73,24 @@ let () =
     (Py.Import.add_module "pyfinalo_explain");
 
   match Sys.argv |> Array.to_list with
+  | _ :: ("--help" | "-h") :: _ ->
+     let help_text = {|pyfinalo_py - Tagless-final DSL exposed to Python
+
+Usage:
+  pyfinalo_py              Start interactive Python REPL
+  pyfinalo_py -            Read Python script from stdin
+  pyfinalo_py --help       Show this help message
+  pyfinalo_py -h           Show this help message
+
+Available modules:
+  pyfinalo         - Direct value interpreter
+  pyfinalo_ast     - Untyped AST interpreter  
+  pyfinalo_explain - Explaining interpreter with type error messages
+
+Example:
+  import pyfinalo as p
+  print(p.show(p.add(p.len(p.str("hello")), p.int(3))))|} in
+     print_endline help_text
   | _ :: "-" :: _ -> Py.Run.any_file (Channel stdin) "stdin" |> ignore
   | _ ->
      let greetings =


### PR DESCRIPTION
## Summary
- Add `--help` and `-h` command line options to pyfinalo_py
- Display usage information, available modules, and example usage
- Follows existing command line parsing pattern

## Test plan
- [x] Test `pyfinalo_py --help` displays help text
- [x] Test `pyfinalo_py -h` displays help text  
- [x] Test stdin mode still works (`echo 'script'  < /dev/null |  pyfinalo_py -`)
- [x] Test REPL mode still works (shows greeting and accepts input)

🤖 Generated with [Claude Code](https://claude.ai/code)